### PR TITLE
 Allow conversations to continue across tabs 

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -3,6 +3,21 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+      "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
     "@most/multicast": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@most/multicast/-/multicast-1.3.0.tgz",
@@ -924,8 +939,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-arraybuffer": {
       "version": "0.1.5",
@@ -965,6 +979,11 @@
         "integer": "^1.0.3",
         "lzz-gyp": "^0.4.2"
       }
+    },
+    "big-integer": {
+      "version": "1.6.41",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.41.tgz",
+      "integrity": "sha512-d5AT9lMTYJ/ZE/4gzxb+5ttPcRWljVsvv7lF1w9KzkPhVUhBtHrjDo1J8swfZKepfLsliDhYa31zRYwcD0Yg9w=="
     },
     "big.js": {
       "version": "3.2.0",
@@ -1012,7 +1031,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1027,6 +1045,20 @@
         "expand-range": "^1.8.1",
         "preserve": "^0.2.0",
         "repeat-element": "^1.1.2"
+      }
+    },
+    "broadcast-channel": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-2.1.9.tgz",
+      "integrity": "sha512-NhmrjBSA3rlOoE92r9xHWB7mmDqb0gcS/NapERZ4vz/I1em5k12gkg7A9+F3xkRT7XujTBj91ywJmUFHgI9LqA==",
+      "requires": {
+        "@babel/runtime": "7.3.1",
+        "detect-node": "2.0.4",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.1.0",
+        "nano-time": "1.0.0",
+        "rimraf": "2.6.3",
+        "unload": "2.1.0"
       }
     },
     "brorand": {
@@ -1278,8 +1310,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "console-browserify": {
       "version": "1.1.0",
@@ -1428,6 +1459,11 @@
       "requires": {
         "repeating": "^2.0.0"
       }
+    },
+    "detect-node": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "diffie-hellman": {
       "version": "5.0.2",
@@ -1750,6 +1786,11 @@
         "for-in": "^1.0.1"
       }
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
     "fsevents": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
@@ -1846,7 +1887,6 @@
           "version": "0.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -1871,8 +1911,7 @@
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -1889,8 +1928,7 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
@@ -1909,20 +1947,17 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.x.x"
           }
@@ -1995,8 +2030,7 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -2119,7 +2153,6 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.x.x",
             "cryptiles": "2.x.x",
@@ -2167,7 +2200,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2181,8 +2213,7 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -2278,7 +2309,8 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.1",
@@ -2397,8 +2429,7 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -2436,7 +2467,6 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -2488,8 +2518,7 @@
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "semver": {
           "version": "5.3.0",
@@ -2513,7 +2542,6 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -2547,7 +2575,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2558,7 +2585,6 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -2587,7 +2613,6 @@
           "version": "2.2.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -2643,8 +2668,7 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -2682,6 +2706,19 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
     },
     "glob-base": {
       "version": "0.3.0",
@@ -2858,11 +2895,19 @@
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inspectpack": {
       "version": "2.2.4",
@@ -3136,6 +3181,11 @@
         "whatwg-fetch": ">=0.10.0"
       }
     },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -3362,6 +3412,11 @@
         "regex-cache": "^0.4.2"
       }
     },
+    "microseconds": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.1.0.tgz",
+      "integrity": "sha1-R9x7z2IXG4Aw4hUv2C8SpolKcRk="
+    },
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -3403,7 +3458,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -3446,6 +3500,14 @@
       "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
       "dev": true,
       "optional": true
+    },
+    "nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
+      "requires": {
+        "big-integer": "^1.6.16"
+      }
     },
     "negotiator": {
       "version": "0.6.1",
@@ -3539,6 +3601,14 @@
       "requires": {
         "for-own": "^0.1.4",
         "is-extendable": "^0.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
       }
     },
     "optimist": {
@@ -3681,8 +3751,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-type": {
       "version": "1.1.0",
@@ -4145,6 +4214,14 @@
         "align-text": "^0.1.1"
       }
     },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
     "ripemd160": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
@@ -4550,6 +4627,30 @@
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
       "dev": true
     },
+    "unload": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.1.0.tgz",
+      "integrity": "sha512-vOg/orTFrHv60iWLZbBpgrgoFaSovkcgQJUmBHNGFWlSFdwtoANZaT3uSePVhggkWSsPxs2rpBl5LHpmcSGjRw==",
+      "requires": {
+        "@babel/runtime": "7.1.5",
+        "detect-node": "2.0.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
+          "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
     "url": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -4778,6 +4879,11 @@
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
       }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
       "version": "1.1.5",

--- a/js/package.json
+++ b/js/package.json
@@ -2,6 +2,7 @@
   "name": "watson-conversation",
   "private": true,
   "dependencies": {
+    "broadcast-channel": "^2.1.9",
     "core-js": "^2.5.3",
     "deepmerge": "^2.2.1",
     "jstz": "^2.0.0",

--- a/js/src/ChatBox.jsx
+++ b/js/src/ChatBox.jsx
@@ -12,6 +12,9 @@ import CallInterface from './CallInterface.jsx';
 
 import 'whatwg-fetch';
 
+// Shim for BroadcastChannel until it is implemented in all browsers
+import BroadcastChannel from 'broadcast-channel';
+
 export default class ChatBox extends Component {
     constructor(props) {
         super(props);
@@ -80,8 +83,8 @@ export default class ChatBox extends Component {
         if (!this.state.convStarted && !this.props.isMinimized) {
             new Promise(
                 (resolve, reject) => {
-                    this.bc.onmessage = function (ev) {
-                        resolve(ev.data);
+                    this.bc.onmessage = function (state) {
+                        resolve(state);
                     }.bind(this);
 
                     setTimeout(function() {
@@ -101,8 +104,8 @@ export default class ChatBox extends Component {
                     this.sendMessage();
                 })
                 .finally(() => {
-                    this.bc.onmessage = function (ev) {
-                        this.setState(ev.data);
+                    this.bc.onmessage = function (state) {
+                        this.setState(state);
                     }.bind(this);
                 });
 

--- a/js/src/ChatBox.jsx
+++ b/js/src/ChatBox.jsx
@@ -85,14 +85,17 @@ export default class ChatBox extends Component {
                     }.bind(this);
 
                     setTimeout(function() {
-                        reject("Done waiting");
+                        reject();
                     }.bind(this), 250);
 
                     localStorage.setItem('watson_bot_request_state', Date.now());
+                    localStorage.removeItem('watson_bot_request_state');
                 }
             )
                 .then((state) => {
                     this.setState(state);
+
+                    this.loadedMessages = this.state.messages.length;
                 })
                 .catch(() => {
                     this.sendMessage();
@@ -128,10 +131,6 @@ export default class ChatBox extends Component {
     }
 
     componentDidUpdate(prevProps, prevState) {
-        if (!this.state.convStarted && !this.props.isMinimized) {
-            this.sendMessage();
-        }
-
         if (prevState.messages.length !== this.state.messages.length) {
             // Ensure that chat box stays scrolled to bottom
             if (typeof(this.messageList) !== 'undefined') {


### PR DESCRIPTION
As per Issue #1, added `BroadcastChannel` and a promise to attempt to allow conversations to continue across different tabs and windows. The result is that new conversations begin with the state from existing tabs, if any exist, and an update in one tab updates all open tabs using the same localStorage.

A BroadcastChannel is added so that the state may be shared across all tabs. Each time the state is saved, it is broadcast to all channels.

A listener is also added so that any time a value is added to and immediately removed from `watson_bot_request_state` on localStorage, the sate is saved, forcing the broadcast. During the initial creation of the chat window, `componentDidMount`, before sending the initial message, the new window makes an entry in localStorage to request the state and waits for 250ms. If a broadcast is made in that time, it takes the initial state from that broadcast. Otherwise, it proceeds to send the initial message. Finally, the BroadcastChannel is set to listen and update the state on all future broadcasts.

The second `this.sendMessage()` was removed from `componentDidUpdate` because it seems redundant to the one from `componentDidMount` and it seems to cause issues in Chrome when there is a delay.

Ref #1 