### PR TITLE
Added wp-hooks actions and filters.

### DIFF
--- a/js/src/ChatBox.jsx
+++ b/js/src/ChatBox.jsx
@@ -51,27 +51,24 @@ export default class ChatBox extends Component {
     }
 
     componentWillUnmount() {
+        wp.hooks.doAction('watsonconv_pre_unmount', this.state);
         this.bc.close();
     }
 
     getInitialContext() {
-        return merge(
+        let context = merge(
             watsonconvSettings.context,
             {
                 global: {
                     system: {
                         timezone: jstz.determine().name()
                     }
-                }/*,
-            skills: {
-              'main skill': {
-                  user_defined: {
-                      username: 'Hola!'
-                  }
-              }
-            }*/
+                }
             }
         );
+
+        context = wp.hooks.applyFilters('watsonconv_initial_context', context);
+        return context;
     }
 
     componentDidMount() {
@@ -101,9 +98,11 @@ export default class ChatBox extends Component {
                     this.loadedMessages = this.state.messages.length;
                 })
                 .catch(() => {
+                    wp.hooks.doAction('watsonconv_new_conversation', this.state);
                     this.sendMessage();
                 })
                 .finally(() => {
+                    wp.hooks.doAction('watsonconv_new_tab', this.state);
                     this.bc.onmessage = function (state) {
                         this.setState(state);
                     }.bind(this);
@@ -179,6 +178,7 @@ export default class ChatBox extends Component {
             });
         }
         sendBody.session_id = this.state.session_id;
+        sendBody = wp.hooks.applyFilters('watsonconv_user_message', sendBody);
 
         fetch(watsonconvSettings.apiUrl, {
             headers: {
@@ -194,6 +194,8 @@ export default class ChatBox extends Component {
             }
             return response.json();
         }).then(body => {
+            body = wp.hooks.applyFilters('watsonconv_bot_message', body);
+
             let {generic} = body.output;
 
             this.setState({

--- a/watson-conversation/includes/frontend.php
+++ b/watson-conversation/includes/frontend.php
@@ -371,7 +371,7 @@ class Frontend {
     }
 
     public static function register_scripts() {
-        wp_register_script('watsonconv-chat-app', WATSON_CONV_URL.'app.js', array('jquery'), self::get_version(), true);
+        wp_register_script('watsonconv-chat-app', WATSON_CONV_URL.'app.js', array('jquery', 'wp-hooks'), self::get_version(), true);
         wp_register_style('watsonconv-chatbox', WATSON_CONV_URL.'css/chatbox.css', array('dashicons'), self::get_version());
         wp_enqueue_script('wp-api');
         wp_localize_script( 'wp-api', 'wpApiSettings', array( 'root' => esc_url_raw( rest_url() ), 'nonce' => wp_create_nonce( 'wp_rest' ) ) );


### PR DESCRIPTION
This request is related to the request in #4 and attempts to add those hooks.

It accomplishes this by adding `wp-hooks` to the current list of scripts which must be loaded, and adds a number of `wp.hooks.doAction` and `wp.hooks.applyFilters` hooks which can be used by other plugins.

The list of added actions, each of which sends the current state as the variable:

* `watsonconv_new_conversation`
* `watsonconv_new_tab`
* `watsonconv_pre_unmount`

The list of added filters:

* `watsonconv_initial_context` - filters the initial context
* `watsonconv_user_message` - filters the body about to be sent to the API
* `watsonconv_bot_message` - filters the body that was received from the API

These changes should allow other plugins to make full use of this plugin, both in JavaScript as well as PHP.

The unfortunate side effect would be that this might alter the minimum required WordPress version for the plugin. If this is a problem, the same functionality is available through an npm package, `@wordpress/hooks`, which could be added to the plugin instead, and a global variable could be defined. However, if backwards compatibility is not a concern, then the current method would likely be best.

Closes #4 